### PR TITLE
chore(ci): switch to OIDC publish

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,5 @@ jobs:
     uses: coroboros/ci/.github/workflows/javascript-npm-packages.yml@v0
     secrets:
       NPM_CONFIG_FILE: ${{ secrets.NPM_CONFIG_FILE }}
-      NPM_EXTRA_CONFIG: ${{ secrets.NPM_EXTRA_CONFIG }}
       NPM_PACKAGE_REGISTRY: ${{ secrets.NPM_PACKAGE_REGISTRY }}
       NPM_PACKAGE_PROXY_REGISTRY: ${{ secrets.NPM_PACKAGE_PROXY_REGISTRY }}
-      NPM_PACKAGE_REGISTRY_TOKEN: ${{ secrets.NPM_PACKAGE_REGISTRY_TOKEN }}


### PR DESCRIPTION
## Summary

Switch publish from token bootstrap to OIDC + provenance. Drops `NPM_PACKAGE_REGISTRY_TOKEN` and `NPM_EXTRA_CONFIG` from the `secrets:` block of `.github/workflows/ci.yml`. The reusable workflow auto-detects the absence of the token and routes the next publish via `pnpm publish --provenance --no-git-checks`. Resulting file matches `coroboros/clone/.github/workflows/ci.yml`.

## Test plan

- [ ] CI preflight green on this PR.
- [ ] Next release tag publishes via OIDC — `npm view @coroboros/location-timezone --json` shows a `provenance` block on the new version.
